### PR TITLE
feat: implemented configuration, authentication, and entity http laye…

### DIFF
--- a/templates/hexagonal/base/src/app.module.ts
+++ b/templates/hexagonal/base/src/app.module.ts
@@ -2,24 +2,20 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { validateEnv } from './infrastructure/common/config/env.validation';
+import { AuthModule } from './infrastructure/common/auth/auth.module';
 import { UserModule } from './infrastructure/user/user.module';
 import { PostModule } from './infrastructure/post/post.module';
 import { CommentModule } from './infrastructure/comment/comment.module';
-import { APP_GUARD } from '@nestjs/core';
-import { JwtAuthGuard } from './infrastructure/common/auth/jwt-auth.guard';
-import { JwtModule } from '@nestjs/jwt';
-import { PassportModule } from '@nestjs/passport';
-import { JwtStrategy } from './infrastructure/common/auth/jwt.strategy';
 
 @Module({
   imports: [
-    // Configuration
+    // Configuration — must be first so all other modules can inject ConfigService
     ConfigModule.forRoot({
       isGlobal: true,
       validate: validateEnv,
     }),
 
-    // Database
+    // Database — configured async so it can inject ConfigService
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -27,34 +23,19 @@ import { JwtStrategy } from './infrastructure/common/auth/jwt.strategy';
         type: 'postgres',
         url: configService.get<string>('DATABASE_URL'),
         autoLoadEntities: true,
+        // Never synchronize in production — use migrations instead
         synchronize: configService.get<string>('NODE_ENV') !== 'production',
       }),
     }),
 
-    // Authentication Setup
-    PassportModule.register({ defaultStrategy: 'jwt' }),
-    JwtModule.registerAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.getOrThrow<string>('JWT_SECRET'),
-        signOptions: {
-          expiresIn: configService.getOrThrow<string>('JWT_EXPIRES_IN') as any,
-        },
-      }),
-    }),
+    // Authentication — wires JwtModule, PassportModule, JwtStrategy, and the global JwtAuthGuard.
+    // All routes are protected by default; use @Public() to opt specific routes out.
+    AuthModule,
 
-    // Domain Modules
+    // Domain Feature Modules
     UserModule,
     PostModule,
     CommentModule,
-  ],
-  providers: [
-    JwtStrategy,
-    {
-      provide: APP_GUARD,
-      useClass: JwtAuthGuard,
-    },
   ],
 })
 export class AppModule {}

--- a/templates/hexagonal/base/src/infrastructure/comment/http/comment.controller.ts
+++ b/templates/hexagonal/base/src/infrastructure/comment/http/comment.controller.ts
@@ -3,7 +3,7 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AddCommentUseCase } from '../../../application/comment/add-comment/add-comment.use-case';
 import { AddCommentRequestDto } from './dto/add-comment.request.dto';
 import { AddCommentCommand } from '../../../application/comment/add-comment/add-comment.command';
-import { CommentResponseDto } from '../../../application/comment/common/comment-response.dto';
+import { CommentPresenter, CommentHttpResponse } from './comment.presenter';
 
 @ApiTags('comments')
 @Controller('comments')
@@ -13,9 +13,11 @@ export class CommentController {
   @Post()
   @HttpCode(201)
   @ApiOperation({ summary: 'Add a comment to a post' })
-  @ApiResponse({ status: 201, type: CommentResponseDto })
-  public async addComment(@Body() dto: AddCommentRequestDto): Promise<CommentResponseDto> {
-    const command = new AddCommentCommand(dto.content, dto.authorId, dto.postId);
-    return this.addCommentUseCase.execute(command);
+  @ApiResponse({ status: 201, description: 'Comment added successfully' })
+  public async addComment(@Body() dto: AddCommentRequestDto): Promise<CommentHttpResponse> {
+    const result = await this.addCommentUseCase.execute(
+      new AddCommentCommand(dto.content, dto.authorId, dto.postId),
+    );
+    return CommentPresenter.toResponse(result);
   }
 }

--- a/templates/hexagonal/base/src/infrastructure/comment/http/comment.presenter.ts
+++ b/templates/hexagonal/base/src/infrastructure/comment/http/comment.presenter.ts
@@ -1,0 +1,34 @@
+import { CommentResponseDto } from '../../../application/comment/common/comment-response.dto';
+
+/**
+ * HTTP response shape for a Comment resource.
+ * Dates are serialised as ISO 8601 strings so JSON consumers get a stable format.
+ */
+export interface CommentHttpResponse {
+  id: string;
+  content: string;
+  authorId: string;
+  postId: string;
+  createdAt: string;
+}
+
+/**
+ * CommentPresenter maps an Application-layer DTO to the final HTTP response shape.
+ *
+ * Responsibilities:
+ * - Re-format fields for HTTP consumers (e.g. Date → ISO string)
+ * - Act as the single seam for future additions (author name, post title, etc.)
+ *
+ * Controllers must always return through a Presenter — never return a raw DTO or entity.
+ */
+export class CommentPresenter {
+  public static toResponse(dto: CommentResponseDto): CommentHttpResponse {
+    return {
+      id: dto.id,
+      content: dto.content,
+      authorId: dto.authorId,
+      postId: dto.postId,
+      createdAt: dto.createdAt.toISOString(),
+    };
+  }
+}

--- a/templates/hexagonal/base/src/infrastructure/common/auth/auth.module.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/auth/auth.module.ts
@@ -1,0 +1,48 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtStrategy } from './jwt.strategy';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+/**
+ * AuthModule encapsulates all authentication infrastructure.
+ *
+ * It wires together:
+ * - PassportModule (the overall auth framework)
+ * - JwtModule (token signing/verification with config-driven options)
+ * - JwtStrategy (validates incoming JWTs via Passport)
+ * - JwtAuthGuard (applied globally as the APP_GUARD — every route is protected by default)
+ *
+ * The global guard + @Public() opt-out pattern:
+ * Routes are protected by default. To mark a route as public (e.g. registration, login),
+ * decorate it with @Public(). This is safer than opt-in auth where a developer
+ * could accidentally forget to add a guard to a sensitive route.
+ */
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.getOrThrow<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRES_IN', '7d') as unknown as number,
+        },
+      }),
+    }),
+  ],
+  providers: [
+    JwtStrategy,
+    {
+      // Registers JwtAuthGuard as a global guard via NestJS DI.
+      // Any module that imports AuthModule will have all its routes protected.
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+  ],
+  exports: [JwtAuthGuard, JwtModule, PassportModule],
+})
+export class AuthModule {}

--- a/templates/hexagonal/base/src/infrastructure/common/auth/jwt.strategy.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/auth/jwt.strategy.ts
@@ -3,6 +3,18 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 
+/**
+ * JWT payload shape as defined by PRD §9 (payload minimalism).
+ * The token contains only the user ID — no PII like email or display name.
+ * If additional user data is needed after authentication, it is fetched
+ * from the database using the userId from this payload.
+ */
+interface JwtPayload {
+  sub: string;
+  iat: number;
+  exp: number;
+}
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(private readonly configService: ConfigService) {
@@ -13,10 +25,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  public async validate(payload: any): Promise<{ userId: string; email: string }> {
-    if (!payload.sub || !payload.email) {
+  public validate(payload: JwtPayload): { userId: string } {
+    if (!payload.sub) {
       throw new UnauthorizedException('Invalid token payload');
     }
-    return { userId: payload.sub, email: payload.email };
+    // Attach to request.user — downstream handlers access current user via @CurrentUser()
+    return { userId: payload.sub };
   }
 }

--- a/templates/hexagonal/base/src/infrastructure/common/config/app.config.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/config/app.config.ts
@@ -1,0 +1,30 @@
+import { registerAs } from '@nestjs/config';
+
+/**
+ * Application-level configuration namespace.
+ *
+ * Inject with: @Inject(appConfig.KEY) private readonly config: ConfigType<typeof appConfig>
+ *
+ * Why `registerAs`?
+ * It namespaces config keys to avoid collisions and provides type-safe access
+ * via ConfigService.get('app.port') or ConfigType<typeof appConfig>.
+ * Controllers and services must never call process.env directly — always use this.
+ */
+export const appConfig = registerAs('app', () => ({
+  /**
+   * The port the HTTP server listens on.
+   * Default: 3000 (safe for local dev; override in prod via environment).
+   */
+  port: parseInt(process.env.PORT ?? '3000', 10),
+
+  /**
+   * The Node environment. Controls things like Swagger availability and DB sync.
+   */
+  nodeEnv: process.env.NODE_ENV ?? 'development',
+
+  /**
+   * CORS origin allowed to access this API.
+   * Use '*' only in development. In production, set to your frontend's exact origin.
+   */
+  corsOrigin: process.env.APP_CORS_ORIGIN ?? '*',
+}));

--- a/templates/hexagonal/base/src/infrastructure/common/config/auth.config.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/config/auth.config.ts
@@ -1,0 +1,24 @@
+import { registerAs } from '@nestjs/config';
+
+/**
+ * Authentication configuration namespace.
+ *
+ * Inject with: @Inject(authConfig.KEY) private readonly config: ConfigType<typeof authConfig>
+ */
+export const authConfig = registerAs('auth', () => ({
+  /**
+   * The secret key used to sign and verify JWTs.
+   * Must be at least 32 characters long (enforced by Zod env validation).
+   * Treat this like a password — never commit it to version control.
+   */
+  jwtSecret: process.env.JWT_SECRET,
+
+  /**
+   * How long a JWT remains valid before the client must re-authenticate.
+   * Accepts zeit/ms strings: '7d', '24h', '60m', etc.
+   * Default: '7d' (safe for most web apps; shorten for high-security contexts).
+   *
+   * PRD §9: Must be configurable via environment variable.
+   */
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? '7d',
+}));

--- a/templates/hexagonal/base/src/infrastructure/common/config/database.config.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/config/database.config.ts
@@ -1,0 +1,26 @@
+import { registerAs } from '@nestjs/config';
+
+/**
+ * Database configuration namespace.
+ *
+ * Inject with: @Inject(databaseConfig.KEY) private readonly config: ConfigType<typeof databaseConfig>
+ *
+ * The URL-first approach is used here (DATABASE_URL) because it is the standard
+ * for cloud providers (Heroku, Railway, Render, Supabase) and avoids managing
+ * separate host/port/user/password variables in the environment.
+ */
+export const databaseConfig = registerAs('database', () => ({
+  /**
+   * Full PostgreSQL connection URL.
+   * Format: postgres://user:password@host:port/dbname
+   * Required — the app will refuse to start without it (enforced by Zod env validation).
+   */
+  url: process.env.DATABASE_URL,
+
+  /**
+   * Whether to auto-synchronise the TypeORM schema with your entities.
+   * MUST be false in production to prevent accidental data loss.
+   * Safe to enable in development only.
+   */
+  synchronize: process.env.NODE_ENV !== 'production',
+}));

--- a/templates/hexagonal/base/src/infrastructure/post/http/post.controller.ts
+++ b/templates/hexagonal/base/src/infrastructure/post/http/post.controller.ts
@@ -5,7 +5,7 @@ import { PublishPostUseCase } from '../../../application/post/publish-post/publi
 import { GetPostUseCase } from '../../../application/post/get-post/get-post.use-case';
 import { CreatePostRequestDto } from './dto/create-post.request.dto';
 import { CreatePostCommand } from '../../../application/post/create-post/create-post.command';
-import { PostResponseDto } from '../../../application/post/common/post-response.dto';
+import { PostPresenter, PostHttpResponse } from './post.presenter';
 
 @ApiTags('posts')
 @Controller('posts')
@@ -19,25 +19,29 @@ export class PostController {
   @Post()
   @HttpCode(201)
   @ApiOperation({ summary: 'Create a new draft post' })
-  @ApiResponse({ status: 201, type: PostResponseDto })
-  public async createPost(@Body() dto: CreatePostRequestDto): Promise<PostResponseDto> {
-    const command = new CreatePostCommand(dto.title, dto.content, dto.authorId);
-    return this.createPostUseCase.execute(command);
+  @ApiResponse({ status: 201, description: 'Draft post created successfully' })
+  public async createPost(@Body() dto: CreatePostRequestDto): Promise<PostHttpResponse> {
+    const result = await this.createPostUseCase.execute(
+      new CreatePostCommand(dto.title, dto.content, dto.authorId),
+    );
+    return PostPresenter.toResponse(result);
   }
 
   @Get(':id')
   @HttpCode(200)
   @ApiOperation({ summary: 'Get a post by ID' })
-  @ApiResponse({ status: 200, type: PostResponseDto })
-  public async getPost(@Param('id') id: string): Promise<PostResponseDto> {
-    return this.getPostUseCase.execute(id);
+  @ApiResponse({ status: 200, description: 'Post returned successfully' })
+  public async getPost(@Param('id') id: string): Promise<PostHttpResponse> {
+    const result = await this.getPostUseCase.execute(id);
+    return PostPresenter.toResponse(result);
   }
 
   @Patch(':id/publish')
   @HttpCode(200)
   @ApiOperation({ summary: 'Publish a draft post' })
-  @ApiResponse({ status: 200, type: PostResponseDto })
-  public async publishPost(@Param('id') id: string): Promise<PostResponseDto> {
-    return this.publishPostUseCase.execute(id);
+  @ApiResponse({ status: 200, description: 'Post published successfully' })
+  public async publishPost(@Param('id') id: string): Promise<PostHttpResponse> {
+    const result = await this.publishPostUseCase.execute(id);
+    return PostPresenter.toResponse(result);
   }
 }

--- a/templates/hexagonal/base/src/infrastructure/post/http/post.presenter.ts
+++ b/templates/hexagonal/base/src/infrastructure/post/http/post.presenter.ts
@@ -1,0 +1,38 @@
+import { PostResponseDto } from '../../../application/post/common/post-response.dto';
+
+/**
+ * HTTP response shape for a Post resource.
+ * Dates are serialised as ISO 8601 strings so JSON consumers get a stable format.
+ */
+export interface PostHttpResponse {
+  id: string;
+  title: string;
+  content: string;
+  authorId: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * PostPresenter maps an Application-layer DTO to the final HTTP response shape.
+ *
+ * Responsibilities:
+ * - Re-format fields for HTTP consumers (e.g. Date → ISO string)
+ * - Act as the single seam for future additions (comment counts, links, etc.)
+ *
+ * Controllers must always return through a Presenter — never return a raw DTO or entity.
+ */
+export class PostPresenter {
+  public static toResponse(dto: PostResponseDto): PostHttpResponse {
+    return {
+      id: dto.id,
+      title: dto.title,
+      content: dto.content,
+      authorId: dto.authorId,
+      status: dto.status,
+      createdAt: dto.createdAt.toISOString(),
+      updatedAt: dto.updatedAt.toISOString(),
+    };
+  }
+}

--- a/templates/hexagonal/base/src/infrastructure/user/http/user.controller.ts
+++ b/templates/hexagonal/base/src/infrastructure/user/http/user.controller.ts
@@ -4,7 +4,8 @@ import { RegisterUserUseCase } from '../../../application/user/register-user/reg
 import { GetUserProfileUseCase } from '../../../application/user/get-user-profile/get-user-profile.use-case';
 import { RegisterUserRequestDto } from './dto/register-user.request.dto';
 import { RegisterUserCommand } from '../../../application/user/register-user/register-user.command';
-import { UserResponseDto } from '../../../application/user/common/user-response.dto';
+import { Public } from '../../common/auth/public.decorator';
+import { UserPresenter, UserHttpResponse } from './user.presenter';
 
 @ApiTags('users')
 @Controller('users')
@@ -16,18 +17,22 @@ export class UserController {
 
   @Post()
   @HttpCode(201)
+  @Public() // Registration is open — no JWT required
   @ApiOperation({ summary: 'Register a new user' })
-  @ApiResponse({ status: 201, type: UserResponseDto })
-  public async registerUser(@Body() dto: RegisterUserRequestDto): Promise<UserResponseDto> {
-    const command = new RegisterUserCommand(dto.email, dto.name, dto.password);
-    return this.registerUserUseCase.execute(command);
+  @ApiResponse({ status: 201, description: 'User registered successfully' })
+  public async registerUser(@Body() dto: RegisterUserRequestDto): Promise<UserHttpResponse> {
+    const result = await this.registerUserUseCase.execute(
+      new RegisterUserCommand(dto.email, dto.name, dto.password),
+    );
+    return UserPresenter.toResponse(result);
   }
 
   @Get(':id')
   @HttpCode(200)
-  @ApiOperation({ summary: 'Get user profile' })
-  @ApiResponse({ status: 200, type: UserResponseDto })
-  public async getUserProfile(@Param('id') id: string): Promise<UserResponseDto> {
-    return this.getUserProfileUseCase.execute(id);
+  @ApiOperation({ summary: 'Get user profile by ID' })
+  @ApiResponse({ status: 200, description: 'User profile returned successfully' })
+  public async getUserProfile(@Param('id') id: string): Promise<UserHttpResponse> {
+    const result = await this.getUserProfileUseCase.execute(id);
+    return UserPresenter.toResponse(result);
   }
 }

--- a/templates/hexagonal/base/src/infrastructure/user/http/user.presenter.ts
+++ b/templates/hexagonal/base/src/infrastructure/user/http/user.presenter.ts
@@ -1,0 +1,33 @@
+import { UserResponseDto } from '../../../application/user/common/user-response.dto';
+
+/**
+ * HTTP response shape for a User resource.
+ * Dates are serialised as ISO 8601 strings so JSON consumers get a stable format.
+ */
+export interface UserHttpResponse {
+  id: string;
+  email: string;
+  name: string;
+  createdAt: string;
+}
+
+/**
+ * UserPresenter maps an Application-layer DTO to the final HTTP response shape.
+ *
+ * Responsibilities:
+ * - Re-format fields for HTTP consumers (e.g. Date → ISO string)
+ * - Exclude internal fields that must not be exposed (e.g. passwordHash)
+ * - Act as the single seam where future HATEOAS links or versioned shapes can be added
+ *
+ * Controllers must always return through a Presenter — never return a raw DTO or entity.
+ */
+export class UserPresenter {
+  public static toResponse(dto: UserResponseDto): UserHttpResponse {
+    return {
+      id: dto.id,
+      email: dto.email,
+      name: dto.name,
+      createdAt: dto.createdAt.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Implements the remaining critical infrastructure components required by PRD-01 §6.2–6.4. This PR adds an `AuthModule` that properly encapsulates JWT authentication wiring, introduces a Presenter layer (User, Post, Comment) between Use Cases and HTTP responses, adds three typed configuration namespaces (`appConfig`, `databaseConfig`, `authConfig`) so that no code reaches `process.env` directly, and corrects the JWT payload to contain only `{ sub: userId }` as required by PRD-01 §9. AppModule is refactored to import `AuthModule` instead of wiring auth inline.

---

## Why?

Fixes #6 - Critical Gaps: Auth Module, Presenters, Typed Config, JWT

---

## Type of change

- [ ] Bug fix
- [x] New feature (new architecture, ORM, optional module, etc.)
- [x] Template change (modifies generated output)
- [ ] CLI change (modifies the prompt flow or composer)
- [ ] Documentation
- [ ] Refactor (no behavior change)
- [ ] Tests only

---

## Checklist

**If you changed a template:**

- [x] The generated project compiles (`npm run build` in the generated output)
- [x] The generated project passes linting (`npm run lint`)
- [x] The generated project's tests pass (`npm run test`)
- [x] No `.ejs` extension leaks into the generated output
- [x] No hardcoded project names, everything uses `<%= projectName %>` or equivalent
- [x] No secrets or credentials in any template file

**If you added a new architecture or ORM:**

- [x] Every folder has a `README.md` that explains what belongs there and why
- [x] All example domain code (User, Post, Comment) is fully implemented, no stubs or TODOs
- [x] Unit tests exist at the domain and application layers
- [x] An e2e test exists in `test/`
- [ ] The architecture transition checklist in `CONTRIBUTING.md` was followed

**Always:**

- [x] I've read `CONTRIBUTING.md` (or I wrote it, in which case this is awkward)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I haven't introduced any `console.log` calls I don't mean to keep
- [x] I haven't committed `.env` or any real credentials

---

## How to test this

```bash
cd templates/hexagonal/base

# 1. Verify all types and build succeed
npm run build

# 2. Run all unit tests
npm test

# 3. Manually verify the auth boundary (optional)
# Start the app, hit POST /users (should be 201, open route via @Public())
# Hit GET /users/:id without a Bearer token (should be 401)
# Hit GET /users/:id with a valid Bearer token (should be 200)
```

---

## Screenshots / recordings (if relevant)

N/A — no CLI prompt flow changes.

---

## Anything the reviewer should know?

**AuthModule and APP_GUARD**: The `JwtAuthGuard` is registered as `APP_GUARD` inside `AuthModule` itself. Importing `AuthModule` into `AppModule` is sufficient to protect all routes globally — no separate `providers` entry is needed in `AppModule`.

**Presenters vs DTO `@ApiProperty`**: Controllers now return `*HttpResponse` plain interfaces. `@ApiResponse` uses `description` strings instead of `type: SomeDto`. A future PR can add `@ApiProperty` annotations to the presenter interfaces for richer Swagger docs.

**JWT payload**: `validate()` in `JwtStrategy` now returns only `{ userId: string }`. Any handler destructuring `email` from `request.user` must fetch email from the database by `userId`. This is intentional per PRD §9 — user data can change after token issuance.

**Files changed:**

- `src/infrastructure/common/auth/auth.module.ts` ✨ new
- `src/infrastructure/common/auth/jwt.strategy.ts` 🔧 JWT payload minimalism fix
- `src/infrastructure/common/config/app.config.ts` ✨ new
- `src/infrastructure/common/config/database.config.ts` ✨ new
- `src/infrastructure/common/config/auth.config.ts` ✨ new
- `src/infrastructure/user/http/user.presenter.ts` ✨ new
- `src/infrastructure/post/http/post.presenter.ts` ✨ new
- `src/infrastructure/comment/http/comment.presenter.ts` ✨ new
- `src/infrastructure/user/http/user.controller.ts` 🔧 routes through UserPresenter, adds @Public() to register
- `src/infrastructure/post/http/post.controller.ts` 🔧 routes through PostPresenter
- `src/infrastructure/comment/http/comment.controller.ts` 🔧 routes through CommentPresenter
- `src/app.module.ts` 🔧 imports AuthModule, removes inline auth wiring
