### PR TITLE
feat: add domain exception filter, fixes (#7)

### DIFF
--- a/templates/hexagonal/base/src/infrastructure/common/filters/domain-exception.filter.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/filters/domain-exception.filter.ts
@@ -1,29 +1,110 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { DomainError } from '../../../domain/common/domain.error';
 
+/**
+ * DomainExceptionFilter — catches all DomainError subclass instances and converts
+ * them to appropriate HTTP responses.
+ *
+ * HTTP Status Code Mapping
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Domain error class name convention → HTTP status
+ *
+ *  *NotFound*         → 404 Not Found
+ *    Examples: UserNotFoundError, PostNotFoundError, CommentNotFoundError
+ *
+ *  *AlreadyInUse*     → 409 Conflict
+ *    Examples: EmailAlreadyInUseError
+ *
+ *  *AlreadySet*       → 409 Conflict
+ *    Examples: EmailAlreadySetError (changing email to the same value)
+ *
+ *  *Unauthorized*     → 401 Unauthorized  (reserved — use NestJS UnauthorizedException for JWT)
+ *
+ *  *Forbidden*        → 403 Forbidden     (reserved — use for ownership violations)
+ *
+ *  Everything else    → 400 Bad Request
+ *    Examples: InvalidEmailError, InvalidNameError, InvalidPostStateTransitionError,
+ *              CannotChangePublishedPostTitleError, InvalidCommentContentError
+ *
+ * Why name-based discrimination?
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The filter catches the abstract DomainError base class. DomainError sets
+ * this.name = this.constructor.name in its constructor, so every subclass
+ * carries a stable, type-safe name string. Checking this.name avoids importing
+ * every concrete error class into the infrastructure layer, which would create
+ * upward dependencies (infrastructure → domain is fine; avoid coupling to
+ * specific error classes when a naming convention is sufficient).
+ *
+ * Response Shape
+ * ─────────────────────────────────────────────────────────────────────────────
+ * {
+ *   "statusCode": 409,
+ *   "timestamp":  "2026-03-20T09:00:00.000Z",
+ *   "path":       "/users",
+ *   "errorType":  "EmailAlreadyInUseError",   ← stable key for frontend i18n
+ *   "message":    "Email foo@bar.com is already in use by another user."
+ * }
+ *
+ * Exposing `errorType` as a stable string lets frontend clients map domain
+ * errors to localised messages without string-matching the human-readable
+ * `message` field, which may change.
+ */
 @Catch(DomainError)
 export class DomainExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(DomainExceptionFilter.name);
+
   public catch(exception: DomainError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    // By default, domain logic violations are bad requests to the API.
-    let status = HttpStatus.BAD_REQUEST;
+    const status = this.resolveHttpStatus(exception);
 
-    // We can explicitly map "NotFound" domain errors to 404s.
-    if (exception.name.includes('NotFound')) {
-      status = HttpStatus.NOT_FOUND;
+    // Log unexpected 500-level domain errors so they show up in server monitoring.
+    // 4xx errors are expected domain behaviour and should not pollute error logs.
+    if (status >= 500) {
+      this.logger.error(
+        `Unhandled domain error: ${exception.name} — ${exception.message}`,
+        exception.stack,
+      );
     }
 
     response.status(status).json({
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
-      // We expose the typed error name to the frontend so they can translate it easily.
+      // Stable, machine-readable key — use this for frontend i18n translation
       errorType: exception.name,
       message: exception.message,
     });
+  }
+
+  /**
+   * Derives the HTTP status code from the domain error's class name.
+   * Using name-convention matching keeps the infrastructure layer decoupled
+   * from individual domain error imports.
+   */
+  private resolveHttpStatus(exception: DomainError): HttpStatus {
+    const name = exception.name;
+
+    if (name.includes('NotFound')) {
+      return HttpStatus.NOT_FOUND; // 404
+    }
+
+    if (name.includes('AlreadyInUse') || name.includes('AlreadySet')) {
+      return HttpStatus.CONFLICT; // 409
+    }
+
+    if (name.includes('Unauthorized')) {
+      return HttpStatus.UNAUTHORIZED; // 401
+    }
+
+    if (name.includes('Forbidden')) {
+      return HttpStatus.FORBIDDEN; // 403
+    }
+
+    // Default: any other domain rule violation is a client error (bad request)
+    return HttpStatus.BAD_REQUEST; // 400
   }
 }


### PR DESCRIPTION
## What does this PR do?

Rewrites `DomainExceptionFilter` with a complete HTTP status mapping table. Previously the filter only mapped `*NotFound*` → 404 and defaulted everything else to 400 — meaning `EmailAlreadyInUseError` returned 400 instead of the semantically correct 409. The new filter adds explicit mappings for 409 (`*AlreadyInUse*`, `*AlreadySet*`), reserve slots for 401/403, and a `Logger` call for any 5xx-level domain errors. The JSDoc block explains the name-convention discrimination strategy and documents the stable JSON response shape.

---

## Why?

Fixes #7 — Missing 409 Conflict mapping in Domain Exception Filter

---

## Type of change

- [x] Bug fix
- [ ] New feature (new architecture, ORM, optional module, etc.)
- [x] Template change (modifies generated output)
- [ ] CLI change
- [ ] Documentation
- [ ] Refactor (no behavior change)
- [ ] Tests only

---

## Checklist

**If you changed a template:**

- [x] The generated project compiles (`npm run build` in the generated output)
- [x] The generated project passes linting (`npm run lint`)
- [x] The generated project's tests pass (`npm run test`)
- [x] No `.ejs` extension leaks into the generated output
- [x] No hardcoded project names
- [x] No secrets or credentials in any template file

**Always:**

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I haven't introduced any `console.log` calls I don't mean to keep
- [x] I haven't committed `.env` or any real credentials

---

## How to test this

```bash
cd templates/hexagonal/base

# Build + unit tests
npm run build && npm test

# Manual verification (requires a running instance):
# 1. Register a user: POST /users  → 201
# 2. Register same email again: POST /users  → 409 Conflict  ← was 400 before this fix
# 3. Fetch nonexistent user: GET /users/bad-id  → 404
# 4. Submit invalid email: POST /users { email: "notanemail" }  → 400
```

---

## Anything the reviewer should know?

**Mapping strategy**: The filter uses `exception.name.includes(...)` on the error class name. This works because `DomainError` sets `this.name = this.constructor.name` in its base constructor — every subclass carries a stable name by convention. This avoids importing every concrete error class from the domain into infrastructure.

**Full mapping table now documented in the filter**:
| Name pattern | HTTP status |
|---|---|
| `*NotFound*` | 404 |
| `*AlreadyInUse*` / `*AlreadySet*` | 409 |
| `*Unauthorized*` | 401 (reserved) |
| `*Forbidden*` | 403 (reserved) |
| _(anything else)_ | 400 |

**File changed:**

- `src/infrastructure/common/filters/domain-exception.filter.ts` 🔧 Full rewrite
