### PR TITLE
feat: implement post publishing functionality and user profile retrie…

### DIFF
--- a/templates/hexagonal/base/src/application/post/publish-post/publish-post.command.ts
+++ b/templates/hexagonal/base/src/application/post/publish-post/publish-post.command.ts
@@ -1,0 +1,6 @@
+export class PublishPostCommand {
+  constructor(
+    public readonly postId: string,
+    public readonly requestingUserId: string,
+  ) {}
+}

--- a/templates/hexagonal/base/src/application/post/publish-post/publish-post.use-case.spec.ts
+++ b/templates/hexagonal/base/src/application/post/publish-post/publish-post.use-case.spec.ts
@@ -3,9 +3,11 @@ import { PostRepositoryPort } from '../../../domain/post/ports/post.repository.p
 import {
   PostNotFoundError,
   InvalidPostStateTransitionError,
+  UnauthorizedPostActionError,
 } from '../../../domain/post/errors/post.errors';
 import { PostResponseDto } from '../common/post-response.dto';
 import { Post, PostStatus } from '../../../domain/post/entities/post.entity';
+import { PublishPostCommand } from './publish-post.command';
 
 describe('PublishPostUseCase', () => {
   let useCase: PublishPostUseCase;
@@ -44,7 +46,11 @@ describe('PublishPostUseCase', () => {
       mockPostRepository.save.mockResolvedValue();
 
       // Act
-      const result = await useCase.execute('123e4567-e89b-12d3-a456-426614174000');
+      const command = new PublishPostCommand(
+        '123e4567-e89b-12d3-a456-426614174000',
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+      const result = await useCase.execute(command);
 
       // Assert
       expect(mockPostRepository.findById).toHaveBeenCalledWith(
@@ -61,9 +67,39 @@ describe('PublishPostUseCase', () => {
       mockPostRepository.findById.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(useCase.execute('223e4567-e89b-12d3-a456-426614174000')).rejects.toThrow(
+      const command = new PublishPostCommand(
+        '223e4567-e89b-12d3-a456-426614174000',
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+      await expect(useCase.execute(command)).rejects.toThrow(
         new PostNotFoundError('223e4567-e89b-12d3-a456-426614174000'),
       );
+      expect(mockPostRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedPostActionError if the requesting user is not the author', async () => {
+      // Arrange
+      const draftPost = Post.reconstitute(
+        '123e4567-e89b-12d3-a456-426614174000',
+        {
+          title: 'Draft Title',
+          content: 'Some draft content',
+          authorId: '550e8400-e29b-41d4-a716-446655440000',
+          status: PostStatus.DRAFT,
+        },
+        new Date(),
+        new Date(),
+      );
+
+      mockPostRepository.findById.mockResolvedValue(draftPost);
+
+      // Act & Assert
+      const command = new PublishPostCommand(
+        '123e4567-e89b-12d3-a456-426614174000',
+        '999e4567-e89b-12d3-a456-426614174000', // Different user
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(UnauthorizedPostActionError);
       expect(mockPostRepository.save).not.toHaveBeenCalled();
     });
 
@@ -85,7 +121,11 @@ describe('PublishPostUseCase', () => {
 
       // Act & Assert
       // The entity itself throws this domain error
-      await expect(useCase.execute('123e4567-e89b-12d3-a456-426614174000')).rejects.toThrow(
+      const command = new PublishPostCommand(
+        '123e4567-e89b-12d3-a456-426614174000',
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+      await expect(useCase.execute(command)).rejects.toThrow(
         new InvalidPostStateTransitionError('PUBLISHED', 'PUBLISHED'),
       );
 

--- a/templates/hexagonal/base/src/application/post/publish-post/publish-post.use-case.ts
+++ b/templates/hexagonal/base/src/application/post/publish-post/publish-post.use-case.ts
@@ -1,10 +1,14 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { PostResponseDto } from '../common/post-response.dto';
-import { PostNotFoundError } from '../../../domain/post/errors/post.errors';
+import {
+  PostNotFoundError,
+  UnauthorizedPostActionError,
+} from '../../../domain/post/errors/post.errors';
 import {
   PostRepositoryPort,
   POST_REPOSITORY_PORT,
 } from '../../../domain/post/ports/post.repository.port';
+import { PublishPostCommand } from './publish-post.command';
 
 @Injectable()
 export class PublishPostUseCase {
@@ -13,10 +17,14 @@ export class PublishPostUseCase {
     private readonly postRepository: PostRepositoryPort,
   ) {}
 
-  public async execute(postId: string): Promise<PostResponseDto> {
-    const post = await this.postRepository.findById(postId);
+  public async execute(command: PublishPostCommand): Promise<PostResponseDto> {
+    const post = await this.postRepository.findById(command.postId);
     if (!post) {
-      throw new PostNotFoundError(postId);
+      throw new PostNotFoundError(command.postId);
+    }
+
+    if (post.authorId.value !== command.requestingUserId) {
+      throw new UnauthorizedPostActionError();
     }
 
     // 1. Delegate behavior completely to Domain Entity

--- a/templates/hexagonal/base/src/application/user/get-user-profile/get-user-profile.query.ts
+++ b/templates/hexagonal/base/src/application/user/get-user-profile/get-user-profile.query.ts
@@ -1,0 +1,3 @@
+export class GetUserProfileQuery {
+  constructor(public readonly userId: string) {}
+}

--- a/templates/hexagonal/base/src/application/user/get-user-profile/get-user-profile.use-case.spec.ts
+++ b/templates/hexagonal/base/src/application/user/get-user-profile/get-user-profile.use-case.spec.ts
@@ -2,6 +2,7 @@ import { GetUserProfileUseCase } from './get-user-profile.use-case';
 import { UserRepositoryPort } from '../../../domain/user/ports/user.repository.port';
 import { UserNotFoundError } from '../../../domain/user/errors/user.errors';
 import { UserResponseDto } from '../common/user-response.dto';
+import { GetUserProfileQuery } from './get-user-profile.query';
 import { User } from '../../../domain/user/entities/user.entity';
 
 describe('GetUserProfileUseCase', () => {
@@ -40,7 +41,8 @@ describe('GetUserProfileUseCase', () => {
       mockUserRepository.findById.mockResolvedValue(existingUser);
 
       // Act
-      const result = await useCase.execute('123e4567-e89b-12d3-a456-426614174000');
+      const query = new GetUserProfileQuery('123e4567-e89b-12d3-a456-426614174000');
+      const result = await useCase.execute(query);
 
       // Assert
       expect(mockUserRepository.findById).toHaveBeenCalledWith(
@@ -57,7 +59,8 @@ describe('GetUserProfileUseCase', () => {
       mockUserRepository.findById.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(useCase.execute('223e4567-e89b-12d3-a456-426614174000')).rejects.toThrow(
+      const query = new GetUserProfileQuery('223e4567-e89b-12d3-a456-426614174000');
+      await expect(useCase.execute(query)).rejects.toThrow(
         new UserNotFoundError('223e4567-e89b-12d3-a456-426614174000'),
       );
       expect(mockUserRepository.findById).toHaveBeenCalledWith(

--- a/templates/hexagonal/base/src/application/user/get-user-profile/get-user-profile.use-case.ts
+++ b/templates/hexagonal/base/src/application/user/get-user-profile/get-user-profile.use-case.ts
@@ -5,6 +5,7 @@ import {
   UserRepositoryPort,
   USER_REPOSITORY_PORT,
 } from '../../../domain/user/ports/user.repository.port';
+import { GetUserProfileQuery } from './get-user-profile.query';
 
 @Injectable()
 export class GetUserProfileUseCase {
@@ -13,11 +14,11 @@ export class GetUserProfileUseCase {
     private readonly userRepository: UserRepositoryPort,
   ) {}
 
-  public async execute(userId: string): Promise<UserResponseDto> {
-    const user = await this.userRepository.findById(userId);
+  public async execute(query: GetUserProfileQuery): Promise<UserResponseDto> {
+    const user = await this.userRepository.findById(query.userId);
 
     if (!user) {
-      throw new UserNotFoundError(userId);
+      throw new UserNotFoundError(query.userId);
     }
 
     return UserResponseDto.fromEntity(user);

--- a/templates/hexagonal/base/src/domain/post/errors/post.errors.ts
+++ b/templates/hexagonal/base/src/domain/post/errors/post.errors.ts
@@ -1,5 +1,11 @@
 import { DomainError } from '../../common/domain.error';
 
+export class UnauthorizedPostActionError extends DomainError {
+  constructor() {
+    super('You do not have permission to perform this action on this post.');
+  }
+}
+
 export class PostNotFoundError extends DomainError {
   constructor(id: string) {
     super(`Post with ID ${id} was not found.`);

--- a/templates/hexagonal/base/src/infrastructure/post/http/post.controller.ts
+++ b/templates/hexagonal/base/src/infrastructure/post/http/post.controller.ts
@@ -5,7 +5,9 @@ import { PublishPostUseCase } from '../../../application/post/publish-post/publi
 import { GetPostUseCase } from '../../../application/post/get-post/get-post.use-case';
 import { CreatePostRequestDto } from './dto/create-post.request.dto';
 import { CreatePostCommand } from '../../../application/post/create-post/create-post.command';
+import { PublishPostCommand } from '../../../application/post/publish-post/publish-post.command';
 import { PostPresenter, PostHttpResponse } from './post.presenter';
+import { CurrentUser } from '../../common/auth/current-user.decorator';
 
 @ApiTags('posts')
 @Controller('posts')
@@ -40,8 +42,11 @@ export class PostController {
   @HttpCode(200)
   @ApiOperation({ summary: 'Publish a draft post' })
   @ApiResponse({ status: 200, description: 'Post published successfully' })
-  public async publishPost(@Param('id') id: string): Promise<PostHttpResponse> {
-    const result = await this.publishPostUseCase.execute(id);
+  public async publishPost(
+    @Param('id') id: string,
+    @CurrentUser() userId: string,
+  ): Promise<PostHttpResponse> {
+    const result = await this.publishPostUseCase.execute(new PublishPostCommand(id, userId));
     return PostPresenter.toResponse(result);
   }
 }

--- a/templates/hexagonal/base/src/infrastructure/user/http/user.controller.spec.ts
+++ b/templates/hexagonal/base/src/infrastructure/user/http/user.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { RegisterUserUseCase } from '../../../application/user/register-user/register-user.use-case';
 import { GetUserProfileUseCase } from '../../../application/user/get-user-profile/get-user-profile.use-case';
+import { GetUserProfileQuery } from '../../../application/user/get-user-profile/get-user-profile.query';
 import { RegisterUserRequestDto } from './dto/register-user.request.dto';
 import { UserResponseDto } from '../../../application/user/common/user-response.dto';
 import { EmailAlreadyInUseError, UserNotFoundError } from '../../../domain/user/errors/user.errors';
@@ -102,7 +103,9 @@ describe('UserController', () => {
       const result = await controller.getUserProfile('user-123');
 
       // Assert
-      expect(mockGetUserProfileUseCase.execute).toHaveBeenCalledWith('user-123');
+      expect(mockGetUserProfileUseCase.execute).toHaveBeenCalledWith(
+        new GetUserProfileQuery('user-123'),
+      );
       expect(result).toEqual({
         id: 'user-123',
         email: 'test@example.com',

--- a/templates/hexagonal/base/src/infrastructure/user/http/user.controller.ts
+++ b/templates/hexagonal/base/src/infrastructure/user/http/user.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body, Get, Param, HttpCode } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { RegisterUserUseCase } from '../../../application/user/register-user/register-user.use-case';
 import { GetUserProfileUseCase } from '../../../application/user/get-user-profile/get-user-profile.use-case';
+import { GetUserProfileQuery } from '../../../application/user/get-user-profile/get-user-profile.query';
 import { RegisterUserRequestDto } from './dto/register-user.request.dto';
 import { RegisterUserCommand } from '../../../application/user/register-user/register-user.command';
 import { Public } from '../../common/auth/public.decorator';
@@ -32,7 +33,7 @@ export class UserController {
   @ApiOperation({ summary: 'Get user profile by ID' })
   @ApiResponse({ status: 200, description: 'User profile returned successfully' })
   public async getUserProfile(@Param('id') id: string): Promise<UserHttpResponse> {
-    const result = await this.getUserProfileUseCase.execute(id);
+    const result = await this.getUserProfileUseCase.execute(new GetUserProfileQuery(id));
     return UserPresenter.toResponse(result);
   }
 }


### PR DESCRIPTION
## What does this PR do?

Resolves Issue #9 by solidifying Application Layer input boundaries through explicit Command and Query objects, replacing loosely-typed primitives (e.g., `postId: string`).

1. **Commands/Queries Added:**
   - `PublishPostCommand` (includes `requestingUserId` for ownership checks).
   - `GetUserProfileQuery`
2. **Author Ownership Enforcement:** Upgraded `PublishPostUseCase` logic to verify that `command.requestingUserId === post.authorId.value`.
3. **New Domain Error:** Added `UnauthorizedPostActionError` to formally handle state manipulation attempts by non-authors.
4. **Controller Integration:** Updated `post.controller.ts` to extract the caller's ID via `@CurrentUser()` and map it into the Command.

---

## Why?

Fixes #9 — Implement Missing Command and Query Input Types (PRD-01 Compliance)

---

## Type of change

- [x] Bug fix (Plugging authorization flaw in publish post)
- [x] New feature (Command/Query definitions)
- [x] Template change (modifies generated output)
- [ ] CLI change
- [ ] Documentation
- [x] Refactor (replacing primitive args with objects)
- [ ] Tests only

---

## Checklist

**If you changed a template:**

- [x] The generated project compiles (`npm run build` in the generated output)
- [x] The generated project passes linting (`npm run lint`)
- [x] The generated project's tests pass (`npm run test`)
- [x] No `.ejs` extension leaks into the generated output
- [x] No hardcoded project names
- [x] No secrets or credentials in any template file

**Always:**

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I haven't introduced any `console.log` calls I don't mean to keep
- [x] I haven't committed `.env` or any real credentials

---

## How to test this

```bash
cd templates/hexagonal/base

# Compile the core logic and test it
npm run build
npm test
```

---

## Anything the reviewer should know?

**Security Note:** `post.publish()` previously could be invoked by anyone who knew the `postId`. The introduction of `PublishPostCommand` deliberately incorporates the `requestingUserId` so the application can definitively shield domain entities from unauthorized manipulation. This complies tightly with PRD §5 (Dedicated Input DTOs).

Files changed:

- `src/application/user/get-user-profile/get-user-profile.query.ts` [NEW]
- `src/application/post/publish-post/publish-post.command.ts` [NEW]
- `src/application/user/get-user-profile/get-user-profile.use-case.ts` [MODIFIED]
- `src/application/post/publish-post/publish-post.use-case.ts` [MODIFIED]
- `src/domain/post/errors/post.errors.ts` [MODIFIED]
- `src/infrastructure/user/http/user.controller.ts` [MODIFIED]
- `src/infrastructure/post/http/post.controller.ts` [MODIFIED]
- Spec files [MODIFIED]
