### PR TITLE
docs: add radme detailing the http, persistence, post, and user domai…

### DIFF
--- a/templates/hexagonal/base/src/domain/post/README.md
+++ b/templates/hexagonal/base/src/domain/post/README.md
@@ -1,0 +1,19 @@
+# Post Domain
+
+This module encapsulates the core business rules and data contracts for blog Posts.
+
+## Core Concepts
+
+- **Post**: The root entity representing an article.
+- **PostId, PostTitle, PostContent**: Value objects enforcing specific validation logic like UUID formats and length constraints.
+- **PostStatus**: Enum (`DRAFT`, `PUBLISHED`, `UNPUBLISHED`) tracking the publishing lifecycle.
+- **PostRepositoryPort**: The persistence abstraction implemented by the Infrastructure layer.
+
+## Rules & Invariants
+
+- A Post title must be between 3 and 200 characters (`InvalidPostTitleLengthError`).
+- A Post content must be at least 10 characters long (`InvalidPostContentLengthError`).
+- Posts start as `DRAFT`.
+- A `DRAFT` can transition to `PUBLISHED`, and a `PUBLISHED` post can become `UNPUBLISHED`.
+- You cannot change the title of a `PUBLISHED` post (`CannotChangePublishedPostTitleError`).
+- Only valid state transitions are permitted (`InvalidPostStateTransitionError`).

--- a/templates/hexagonal/base/src/domain/user/README.md
+++ b/templates/hexagonal/base/src/domain/user/README.md
@@ -1,0 +1,15 @@
+# User Domain
+
+This module encapsulates the core business rules, entities, and data contracts related to the User aggregate.
+
+## Core Concepts
+
+- **User**: The root entity. Responsible for invariants like name validation and email updates.
+- **UserId & Email**: Value Objects that encapsulate type-safety and formatting rules (e.g., email lowercase normalization, UUID structural mapping).
+- **UserRepositoryPort**: The abstraction (interface) for persistence that the Application layer relies upon. The actual implementation lives in `infrastructure/user/persistence/`.
+
+## Rules & Invariants
+
+- A User's name must be between 2 and 100 characters (`InvalidNameError`).
+- Emails are always stored, validated, and compared in lowercase format (`InvalidEmailError`).
+- You cannot change an email to the exact same value (`EmailAlreadySetError`).

--- a/templates/hexagonal/base/src/infrastructure/common/http/README.md
+++ b/templates/hexagonal/base/src/infrastructure/common/http/README.md
@@ -13,6 +13,17 @@ This sub-layer handles delivery of our application via REST APIs.
 - **Business Logic**: Controllers should be ultra-thin. If you see complex `if/else` logic here, it should be moved to a Use Case or Entity.
 - **Direct Database Calls**: Never use a Repository or Query builder directly in a controller.
 
+## Global Guardianship & Open Routes
+
+By default, the entire application surface area is locked down. We use a **Global JWT Auth Guard** mapped in `app.module.ts` via `APP_GUARD`.
+To open a specific route to unauthenticated users, you **MUST explicitly opt-out** using the `@Public()` decorator.
+
+```typescript
+@Public()
+@Get('health')
+public healthCheck() { ... }
+```
+
 ## Why this boundary exists
 
 The HTTP layer is just one way to "drive" the application. By keeping it isolated, we can easily add other triggers (CLI commands, Cron jobs, Message Queue handlers) without duplicating code or coupling our logic to the specific behavior of the Express/Fastify request-response lifecycle.

--- a/templates/hexagonal/base/src/infrastructure/common/persistence/README.md
+++ b/templates/hexagonal/base/src/infrastructure/common/persistence/README.md
@@ -13,6 +13,13 @@ This sub-layer handles the translation between our pure Domain Entities and the 
 - **Business Logic**: Never put validation or state transition rules in a Mapper or Repository.
 - **Leaking ORM Models**: Never return an `OrmEntity` from a repository; always map it back to a Domain Entity first.
 
+## The Adapter & Mapper Pattern
+
+We strictly enforce isolation by mapping ORM schemas into pure Domain Entities:
+
+1. **Adapaters**: (`UserRepositoryAdapter`) implements the `UserRepositoryPort`. It handles raw database interactions using TypeORM repositories.
+2. **Mappers**: (`UserMapper.toDomain()`, `UserMapper.toOrm()`) translate the ORM entities (e.g. `UserOrmEntity`) into the rich behavioral Domain Entities (`User`) before handing them back to the Application Layer.
+
 ## Why this boundary exists
 
 By separating the ORM from the Domain, we ensure that changes to our database schema do not force changes to our business logic. This allows us to swap TypeORM for another persistence tool (like Prisma or MikroORM) by only touching this layer.


### PR DESCRIPTION
## What does this PR do?

Resolves Issue #10 by completing the "README-driven architecture" documentation mandated by PRD-01.

1. **New Domain READMEs:** Created boundary documentation for the User and Post domains.
   - `src/domain/user/README.md`: Explains Name constraint, Email formatting, and `UserRepositoryPort`.
   - `src/domain/post/README.md`: Explains Title/Content constraints, Status lifecycles, and `PostRepositoryPort`.
2. **Persistence Enhancements:** Updated `src/infrastructure/common/persistence/README.md` to formally document the TypeORM `Adapter` & `Mapper` isolation pattern.
3. **HTTP Enhancements:** Updated `src/infrastructure/common/http/README.md` to document the global JWT Guardianship strategy and how to use `@Public()` to opt-out.

---

## Why?

Fixes #10 — Complete Missing Architecture READMEs (PRD-01 Compliance)

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Template change
- [ ] CLI change
- [x] Documentation
- [ ] Refactor
- [ ] Tests only

---

## Checklist

**If you changed a template:**

- [x] The generated project compiles (`npm run build` in the generated output)
- [x] The generated project passes linting (`npm run lint`)
- [x] The generated project's tests pass (`npm run test`)
- [x] No `.ejs` extension leaks into the generated output
- [x] No hardcoded project names
- [x] No secrets or credentials in any template file

**Always:**

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I haven't introduced any `console.log` calls I don't mean to keep
- [x] I haven't committed `.env` or any real credentials

---

## Anything the reviewer should know?

By maintaining explicit READMEs deep in the architecture tree, we fulfill the project philosophy that developers should be able to ascertain the "Rules & Invariants" of a module without context-switching back to the highest-level PRD.

Files changed:

- `src/domain/user/README.md` [NEW]
- `src/domain/post/README.md` [NEW]
- `src/infrastructure/common/persistence/README.md` [MODIFIED]
- `src/infrastructure/common/http/README.md` [MODIFIED]
