### PR TITLE
fix: environment variable jwt expires increase from 1h to 7d, fixes (…

### DIFF
--- a/templates/hexagonal/base/src/infrastructure/common/config/env.validation.ts
+++ b/templates/hexagonal/base/src/infrastructure/common/config/env.validation.ts
@@ -5,7 +5,7 @@ export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
   DATABASE_URL: z.string().url(),
   JWT_SECRET: z.string().min(32),
-  JWT_EXPIRES_IN: z.string().default('1h'),
+  JWT_EXPIRES_IN: z.string().default('7d'),
   APP_CORS_ORIGIN: z.string().default('*'),
 });
 


### PR DESCRIPTION
## What does this PR do?

Resolves Issue #12 by updating the global default for JSON Web Token expiration.

1. **JWT Expiry Default:** Altered the `zod` schema default for `JWT_EXPIRES_IN` inside `src/infrastructure/common/config/env.validation.ts` from `'1h'` to `'7d'`.

---

## Why?

Fixes #12 — Incorrect JWT Default Expiry. PRD-01 Section 9 explicitly mandates a 7-day default lifespan for issued identity tokens.

---

## Type of change

- [x] Bug fix (Aligning default value with PRD spec)
- [ ] New feature
- [ ] Template change
- [ ] CLI change
- [ ] Documentation
- [ ] Refactor
- [ ] Tests only

---

## Checklist

**If you changed a template:**

- [x] The generated project compiles (`npm run build` in the generated output)
- [x] The generated project passes linting (`npm run lint`)
- [x] The generated project's tests pass (`npm run test`)
- [x] No `.ejs` extension leaks into the generated output
- [x] No hardcoded project names
- [x] No secrets or credentials in any template file

**Always:**

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I haven't introduced any `console.log` calls I don't mean to keep
- [x] I haven't committed `.env` or any real credentials

---

## Anything the reviewer should know?

Files changed:

- `src/infrastructure/common/config/env.validation.ts` [MODIFIED]
