### PR TITLE
feat: implement template overlay resolution system for dynamic templa…

### DIFF
--- a/cli/src/composer/__tests__/resolveSourcePaths.spec.ts
+++ b/cli/src/composer/__tests__/resolveSourcePaths.spec.ts
@@ -1,23 +1,66 @@
 import { resolveSourcePaths } from '../resolveSourcePaths';
 import * as path from 'path';
+import * as fs from 'fs-extra';
+import { ComposerContext } from '../compose';
+
+jest.mock('fs-extra', () => ({
+  existsSync: jest.fn(),
+}));
+
+const mockContext: ComposerContext = {
+  projectName: 'test',
+  architecture: 'hexagonal',
+  packageManager: 'npm',
+  orm: 'typeorm',
+  database: 'postgresql',
+  auth: 'jwt',
+  optionalModules: ['redis', 'swagger'],
+  includeExampleCode: true,
+};
 
 describe('resolveSourcePaths()', () => {
-  it('always includes the shared templates path', () => {
-    const paths = resolveSourcePaths('hexagonal');
-    expect(paths.some((p) => p.includes('shared'))).toBe(true);
+  beforeEach(() => {
+    jest.resetAllMocks();
   });
 
-  it('returns the shared path for every architecture variant', () => {
-    const architectures = ['hexagonal', 'ddd', 'modular'] as const;
-    for (const arch of architectures) {
-      const paths = resolveSourcePaths(arch);
-      expect(paths.length).toBeGreaterThanOrEqual(1);
-      expect(paths[0]).toContain('shared');
-    }
-  });
+  it('always includes the shared templates path as the first element', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false); // No other layers exist
 
-  it('shared path is always the first in the list (lowest priority, applied first)', () => {
-    const paths = resolveSourcePaths('hexagonal');
+    const paths = resolveSourcePaths(mockContext);
+    expect(paths).toHaveLength(1);
     expect(path.basename(paths[0])).toBe('shared');
+  });
+
+  it('layers architecture base, ORM, Auth, and Optional modules in the correct order', () => {
+    // Treat all paths as existing
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+
+    const paths = resolveSourcePaths(mockContext);
+
+    // Total layers for this context:
+    // 1 (shared) + 1 (base) + 1 (orm) + 1 (auth) + 2 (optional) = 6 layers
+    expect(paths).toHaveLength(6);
+
+    // Verify correct order (overlay pattern)
+    expect(paths[0]).toContain('shared');
+    expect(paths[1]).toContain(path.normalize('hexagonal/base'));
+    expect(paths[2]).toContain(path.normalize('hexagonal/orm/typeorm'));
+    expect(paths[3]).toContain(path.normalize('hexagonal/auth/jwt'));
+    expect(paths[4]).toContain(path.normalize('hexagonal/optional/redis'));
+    expect(paths[5]).toContain(path.normalize('hexagonal/optional/swagger'));
+  });
+
+  it('does not include layers that do not exist', () => {
+    (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+      // Only pretend base and auth exist
+      return p.includes('base') || p.includes('auth');
+    });
+
+    const paths = resolveSourcePaths(mockContext);
+
+    expect(paths).toHaveLength(3);
+    expect(paths[0]).toContain('shared');
+    expect(paths[1]).toContain(path.normalize('hexagonal/base'));
+    expect(paths[2]).toContain(path.normalize('hexagonal/auth/jwt'));
   });
 });

--- a/cli/src/composer/compose.ts
+++ b/cli/src/composer/compose.ts
@@ -41,7 +41,7 @@ export async function compose(options: ComposerOptions): Promise<void> {
   const { outputDir, context, dryRun = false, skipGit = false, verbose = false } = options;
 
   // Step 1: Resolve source template paths
-  const sourcePaths = resolveSourcePaths(context.architecture);
+  const sourcePaths = resolveSourcePaths(context);
 
   // Step 2: Build the EJS context object
   const ejsContext = buildContext(context);

--- a/cli/src/composer/resolveSourcePaths.ts
+++ b/cli/src/composer/resolveSourcePaths.ts
@@ -1,28 +1,45 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { resolveTemplatesDir } from '../utils/pathUtils';
+import { ComposerContext } from './compose';
 
 /**
  * Resolves the ordered list of template source directories for a given architecture.
  *
- * In Phase 0, only the shared template directory is returned.
- * Subsequent phases will return [shared/, hexagonal/base/, hexagonal/orm/typeorm/, ...]
+ * Implements the 5-layer overlay system:
+ * Layer 1: Shared templates
+ * Layer 2: Architecture-specific base
+ * Layer 3: ORM-specific overlay
+ * Layer 4: Auth-specific overlay
+ * Layer 5: Optional module overlays
  *
- * PRD-00 6.2 Step 1
+ * PRD-02 §5.1, §5.2
  */
-export function resolveSourcePaths(architecture: 'hexagonal' | 'ddd' | 'modular'): string[] {
+export function resolveSourcePaths(context: ComposerContext): string[] {
   const templatesDir = resolveTemplatesDir();
-  const sharedPath = path.join(templatesDir, 'shared');
+  const paths: string[] = [];
 
-  // Phase 0: only shared templates are generated.
-  // Architecture-specific paths will be layered here in Phase 2+.
-  const paths: string[] = [sharedPath];
+  // Layer 1: Always included
+  paths.push(path.join(templatesDir, 'shared'));
 
-  // Architecture-specific placeholder — no templates exist yet in Phase 0.
-  // This is intentionally a no-op: the directory is reserved but empty.
-  const architecturePath = path.join(templatesDir, architecture);
-  if (fs.existsSync(architecturePath)) {
-    paths.push(architecturePath);
+  // Layer 2: Architecture-specific base
+  const archBase = path.join(templatesDir, context.architecture, 'base');
+  if (fs.existsSync(archBase)) paths.push(archBase);
+
+  // Layer 3: ORM-specific overlay
+  const ormPath = path.join(templatesDir, context.architecture, 'orm', context.orm);
+  if (fs.existsSync(ormPath)) paths.push(ormPath);
+
+  // Layer 4: Auth-specific overlay
+  if (context.auth !== 'none') {
+    const authPath = path.join(templatesDir, context.architecture, 'auth', context.auth);
+    if (fs.existsSync(authPath)) paths.push(authPath);
+  }
+
+  // Layer 5: Optional module overlays
+  for (const mod of context.optionalModules || []) {
+    const modPath = path.join(templatesDir, context.architecture, 'optional', mod);
+    if (fs.existsSync(modPath)) paths.push(modPath);
   }
 
   return paths;


### PR DESCRIPTION
## What does this PR do?

Rewrites `resolveSourcePaths()` to implement the 5-layer overlay system defined in PRD-02. Instead of just loading `[shared, architecture]`, it now dynamically checks and loads `[shared, arch/base, arch/orm/xyz, arch/auth/xyz, arch/optional/xyz]`.

---

## Why?

Fixes #28 — For Phase 2 to work, the composer must stitch together the correct persistence, authentication, and optional module templates on top of the base template.

---

## Type of change

- [x] New feature (Template Overlay Resolution)
- [x] Breaking change (Architecture path changed from `templates/hexagonal/` to `templates/hexagonal/base/`)

---

## Checklist

**If you changed the CLI:**

- [x] `npm run build --workspace=cli` passes with zero TypeScript errors
- [x] `npm run test --workspace=cli` passes
- [x] `resolveSourcePaths` accepts the full `ComposerContext`
- [x] Tests mock `fs.existsSync` to verify ordered array structure

**Always:**

- [x] I follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I haven't introduced any `console.log` calls I don't mean to keep

---

## Changes Made

| File                                                    | Change                                                                                                                         |
| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| `cli/src/composer/resolveSourcePaths.ts`                | Complete rewrite. Implements layer resolution checking `fs.existsSync` sequentially for base, orm, auth, and optional modules. |
| `cli/src/composer/compose.ts`                           | Pass `context` instead of `context.architecture` to `resolveSourcePaths()`.                                                    |
| `cli/src/composer/__tests__/resolveSourcePaths.spec.ts` | Rewritten to use mocked `fs.existsSync` to test overlay order correctness.                                                     |

---

## Anything the reviewer should know?

- `renderFiles.ts` works perfectly with this out of the box. Since it processes the returned paths sequentially and `fs.copy`/`fs.writeFile` overwrites existing files, the _"later layer overrides earlier"_ (overlay pattern) behavior natively occurs without extra file maps.
- Template authors must ensure directories are placed accurately inside `orm/`, `auth/`, and `optional/` as they will now be scanned automatically.
